### PR TITLE
Refatora modal de agendamento — novo layout e envio por e‑mail

### DIFF
--- a/src/app/cadastro-modal/cadastro-modal.component.css
+++ b/src/app/cadastro-modal/cadastro-modal.component.css
@@ -1,138 +1,163 @@
 .modal {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  padding: 1rem;
+  background: rgba(31, 23, 33, 0.72);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1000;
-  color: #676166;
 }
 
 .modal-content {
   position: relative;
-  width: 30%;
-  height: 75%;
-  background-color: white;
-  padding: 20px;
-  border-radius: 3px;
-  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.5);
+  width: min(760px, 100%);
+  max-height: 95vh;
+  overflow-y: auto;
+  background: linear-gradient(145deg, #ffffff, #f9f4f6);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 22px 40px rgba(44, 20, 31, 0.25);
+  color: #3f2f35;
 }
-
 
 .close-button {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  background-color: white;
-  border: none;
-  padding: 5px 10px;
-  border-radius: 3px;
+  top: 1rem;
+  right: 1rem;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid #e7dfe3;
+  background: #fff;
+  color: #5b4850;
+  font-size: 1.35rem;
   cursor: pointer;
 }
 
-/* Ajuste o estilo do botão de fechar */
 .close-button:hover {
-  background-color: #aaa;
+  background: #f3ebef;
 }
 
-.input-group{
-  display:grid;
-  margin-top: 2rem;
-  grid-template-areas: "a";
-}
-.input-box{
-  template-area: a;
-  margin-bottom: 1.1rem;
+.modal-header {
+  margin-bottom: 1.5rem;
 }
 
-.input-box input{
-  width: 90%;
-  margin: 0.6rem 0;
-  padding: 0.8rem 1.2rem;
-  border:none;
-  border-radius: 10px;
-  box-shadow: 1px 1px 6px #0000001c;
+.badge {
+  display: inline-block;
+  margin: 0;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: #f3d8e0;
+  color: #692f42;
+  font-size: 0.85rem;
+  font-weight: 700;
 }
 
-.input-box input::hover{
-  background-color: #eeeeee75;
+.modal-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(1.6rem, 2.8vw, 2.2rem);
 }
 
+.subtitle {
+  margin: 0;
+  color: #6f5b63;
+}
 
-.form-group{
+form {
   display: grid;
-  justify-items: center;
+  gap: 1rem;
 }
 
-.form-group textarea {
-  width: 90%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-}
-.form-group textarea {
-  resize: vertical; /* Permite ajustar verticalmente */
-  min-height: 100px; /* Altura mínima */
-}
-
-.form-groups input[type="date"] {
-  display:flex;
-  margin-top: 2vh;
-  /* Estilos específicos para o campo de data */
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  background-color: white;
-}
-.form-groups  label{
-  margin-top: 2vh;
-}
-.form-groups{
+.input-grid {
   display: grid;
-  margin-left: 3vh;
-  justify-items: start;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.form-buttom{
+.input-box {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.input-box span {
+  font-size: 0.92rem;
+  color: #59464e;
+}
+
+.input-box input,
+.input-box textarea {
+  width: 100%;
+  border: 1px solid #e3d8dd;
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.8rem 0.95rem;
+  font-size: 1rem;
+  color: #3c2e33;
+  transition: 0.2s ease;
+  box-sizing: border-box;
+}
+
+.input-box textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.input-box input:focus,
+.input-box textarea:focus {
+  outline: none;
+  border-color: #c7859c;
+  box-shadow: 0 0 0 4px rgba(199, 133, 156, 0.2);
+}
+
+.terms {
   display: flex;
-  width:100%;
-  height:100%;
-  margin-top: 2vh;
-  justify-content: center;
+  align-items: flex-start;
+  gap: 0.55rem;
+  font-size: 0.92rem;
+  color: #5b4850;
 }
 
+.terms input {
+  margin-top: 0.15rem;
+}
 
-.form-buttom button{
-  margin-top: 8vh;
-  width: 70%;
-  height: 5vh;
-  background-color: #676166;
-  color: white;
-  border-radius: 20px;
-  font-size: 1.3rem;
-  transition: 0.7s;
+.terms a {
+  color: #7d3450;
+  font-weight: 600;
+}
+
+.submit-button {
+  margin-top: 0.35rem;
+  border: none;
+  border-radius: 14px;
+  padding: 0.95rem 1.2rem;
+  background: linear-gradient(90deg, #7b4254, #b26a84);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
   cursor: pointer;
+  transition: 0.25s ease;
 }
 
-.form-buttom button:hover{
-  background-color: #D8B1B2;
-  color:black;
+.submit-button:hover:enabled {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(123, 66, 84, 0.3);
 }
 
+.submit-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 
-@media screen and (max-width:320px), (max-width:420px) {
+@media (max-width: 768px) {
   .modal-content {
-    width: 20rem;
-    height: 45rem;
+    padding: 1.25rem;
+    border-radius: 18px;
   }
-  .modal{
-    width: 27rem;
-  }
-  .form-groups {
-    font-size: 1rem;
+
+  .input-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/app/cadastro-modal/cadastro-modal.component.html
+++ b/src/app/cadastro-modal/cadastro-modal.component.html
@@ -1,35 +1,55 @@
 <div class="modal" *ngIf="modalService.showModal$ | async">
   <div class="modal-content">
-    <h1>Agende uma avaliação</h1>
-    <form (ngSubmit)="submitForm()">
-      <div class="input-group">
-        <div class="input-box">
-      <input type="text" id="nome" name="nome" placeholder="Digite seu nome" [(ngModel)]="nome" required>
+    <button class="close-button" type="button" (click)="close()" aria-label="Fechar modal">×</button>
+
+    <div class="modal-header">
+      <p class="badge">Avaliação personalizada</p>
+      <h1>Agende seu horário</h1>
+      <p class="subtitle">Preencha os dados abaixo e vamos abrir seu aplicativo de e-mail com a solicitação pronta para envio.</p>
+    </div>
+
+    <form (ngSubmit)="submitForm()" #agendamentoForm="ngForm">
+      <div class="input-grid">
+        <label class="input-box" for="nome">
+          <span>Nome completo</span>
+          <input type="text" id="nome" name="nome" placeholder="Digite seu nome" [(ngModel)]="nome" required>
+        </label>
+
+        <label class="input-box" for="email">
+          <span>E-mail</span>
+          <input type="email" id="email" name="email" placeholder="Digite seu e-mail" [(ngModel)]="email" required>
+        </label>
       </div>
-      <div class="input-box">
-      <input type="email" id="email" name="email" placeholder="Digite seu e-mail" [(ngModel)]="email" required>
-    </div>
-    <div class="input-box">
-      <input type="tel" id="telefone" name="telefone" placeholder="Digite seu telefone (xx) xxxx-xxxx" [(ngModel)]="telefone" required>
-    </div>
-  </div>
-  <div class="form-group">
-    <textarea id="descricao" name="descricao" placeholder="Qual especialidade deseja agendar?" [(ngModel)]="descricao" rows="4"></textarea>
-  </div>
-  <div class="form-groups">
-    <label for="data">Escolha uma data:</label>
-    <input type="date" id="data" name="data" [(ngModel)]="data" required>
-  </div>
-  <div class="form-groups">
-    <label for="termos">
-      <input type="checkbox" id="termos" name="termos" [(ngModel)]="aceitoTermos" required>
-      Aceito os <a href="#" target="_blank">termos de serviço</a>
-    </label>
-  </div>
-  <div class="form-buttom">
-  <button type="submit">Enviar</button>
-  </div>
+
+      <div class="input-grid">
+        <label class="input-box" for="telefone">
+          <span>Telefone</span>
+          <input type="tel" id="telefone" name="telefone" placeholder="(xx) xxxxx-xxxx" [(ngModel)]="telefone" required>
+        </label>
+
+        <label class="input-box" for="data">
+          <span>Data desejada</span>
+          <input type="date" id="data" name="data" [(ngModel)]="data" required>
+        </label>
+      </div>
+
+      <label class="input-box" for="descricao">
+        <span>Especialidade desejada</span>
+        <textarea
+          id="descricao"
+          name="descricao"
+          placeholder="Ex.: ortodontia, clareamento, limpeza..."
+          [(ngModel)]="descricao"
+          rows="4"
+        ></textarea>
+      </label>
+
+      <label class="terms" for="termos">
+        <input type="checkbox" id="termos" name="termos" [(ngModel)]="aceitoTermos" required>
+        <span>Aceito os <a href="#" target="_blank">termos de serviço</a>.</span>
+      </label>
+
+      <button type="submit" class="submit-button" [disabled]="agendamentoForm.invalid">Enviar agendamento por e-mail</button>
     </form>
-    <button class="close-button" type="button" (click)="close()">x</button>
   </div>
 </div>

--- a/src/app/cadastro-modal/cadastro-modal.component.ts
+++ b/src/app/cadastro-modal/cadastro-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component} from '@angular/core';
+import { Component } from '@angular/core';
 import { ModalService } from '../modal-service.service';
 
 @Component({
@@ -6,22 +6,60 @@ import { ModalService } from '../modal-service.service';
   templateUrl: './cadastro-modal.component.html',
   styleUrls: ['./cadastro-modal.component.css']
 })
-export class CadastroModalComponent{
-  nome: string = '';
-  email: string = '';
-  telefone: string = '';
-  descricao: string = ''; 
-  data: string = '';
-  aceitoTermos: boolean = false;
+export class CadastroModalComponent {
+  nome = '';
+  email = '';
+  telefone = '';
+  descricao = '';
+  data = '';
+  aceitoTermos = false;
 
-  constructor(public modalService: ModalService) {
-  }
-  close() {
+  private readonly clinicEmail = 'agendamento@clinicathaisyamamoto.com.br';
+
+  constructor(public modalService: ModalService) {}
+
+  close(): void {
     this.modalService.showModal$.next(false);
     document.body.style.overflow = 'auto';
   }
-  submitForm() {
-    // Aqui você pode tratar o envio do formulário, por exemplo, enviar os dados para um serviço ou API.
-    console.log('Formulário enviado!');
+
+  submitForm(): void {
+    const assunto = `Novo agendamento - ${this.nome}`;
+    const mensagem = [
+      'Olá, equipe da clínica!',
+      '',
+      'Recebi uma nova solicitação de agendamento:',
+      `Nome: ${this.nome}`,
+      `E-mail: ${this.email}`,
+      `Telefone: ${this.telefone}`,
+      `Data desejada: ${this.formatDate(this.data)}`,
+      `Especialidade/descrição: ${this.descricao || 'Não informado'}`,
+      `Aceitou os termos: ${this.aceitoTermos ? 'Sim' : 'Não'}`,
+      '',
+      'Mensagem enviada automaticamente pelo site.'
+    ].join('\n');
+
+    const mailtoLink = `mailto:${this.clinicEmail}?subject=${encodeURIComponent(assunto)}&body=${encodeURIComponent(mensagem)}`;
+    window.location.href = mailtoLink;
+
+    this.close();
+    this.resetForm();
+  }
+
+  private formatDate(date: string): string {
+    if (!date) {
+      return 'Não informada';
+    }
+
+    return new Date(`${date}T00:00:00`).toLocaleDateString('pt-BR');
+  }
+
+  private resetForm(): void {
+    this.nome = '';
+    this.email = '';
+    this.telefone = '';
+    this.descricao = '';
+    this.data = '';
+    this.aceitoTermos = false;
   }
 }


### PR DESCRIPTION
### Motivation
- Melhorar a aparência e usabilidade do formulário de agendamento para tornar o fluxo de marcação mais claro e profissional.
- Permitir que as informações preenchidas sejam enviadas facilmente para a clínica via e‑mail sem depender de backend adicional.

### Description
- Reestruturei o modal de agendamento com header, grid de campos, labels e estados visuais mais claros em `src/app/cadastro-modal/cadastro-modal.component.html`.
- Reescrevi os estilos para um layout moderno, responsivo e com foco acessível em `src/app/cadastro-modal/cadastro-modal.component.css`.
- Implementei envio via `mailto:` que monta assunto e corpo com `nome`, `email`, `telefone`, `data`, `descricao` e aceite de termos em `src/app/cadastro-modal/cadastro-modal.component.ts`.
- Adicionei validação de formulário via template-driven (`#agendamentoForm="ngForm"`) e desabilitei o botão de envio quando o formulário está inválido.

### Testing
- Executei o build do projeto com `npm run build` e a construção completou com sucesso.
- O build exibiu apenas um aviso de budget de CSS para o arquivo `cadastro-modal.component.css` e não impediu a compilação.
- Nenhum teste automatizado adicional foi executado nesta mudança.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca962a07dc8330b87e58f5ec937864)